### PR TITLE
Highlight killed world boss

### DIFF
--- a/AltManager/AltManager.lua
+++ b/AltManager/AltManager.lua
@@ -1053,7 +1053,7 @@ function AltManager:CreateContent()
 		worldbosses = {
 			order = 7.9,
 			label = worldboss_label,
-			data = function(alt_data) return alt_data.worldboss and (alt_data.worldboss .. " killed") or "-" end,
+			data = function(alt_data) return alt_data.worldboss and ("|cFF00FF00" .. alt_data.worldboss) or "-" end,
 		},
 		conquest_pts = {
 			order = 8,


### PR DESCRIPTION
Instead of adding suffix "killed" will highlight boss name with green color.

![He1Voil](https://user-images.githubusercontent.com/29861653/103108284-90c71f80-4657-11eb-8e13-ce99dd5310e8.png)
